### PR TITLE
Add modal popup and finalize sign-in/sign-up page layouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@babel/core": "^7.16.0",
         "@fontsource/roboto": "^5.1.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
+        "@reduxjs/toolkit": "^2.5.0",
         "@svgr/webpack": "^5.5.0",
         "babel-jest": "^27.5.1",
         "babel-loader": "^8.2.3",
@@ -3331,6 +3332,40 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.5.0.tgz",
+      "integrity": "sha512-awNe2oTodsZ6LmRqmkFhtb/KH03hUhxOamEQy411m3Njj3BbFvoBovxo4Q1cBWnV1ErprVj9MlF0UPXkng0eyg==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -4089,7 +4124,7 @@
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
       "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4208,6 +4243,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -6692,6 +6733,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -14501,17 +14543,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
-    "node_modules/react-load-script": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/react-load-script/-/react-load-script-0.0.6.tgz",
-      "integrity": "sha512-aRGxDGP9VoLxcsaYvKWIW+LRrMOzz2eEcubTS4NvQPPugjk2VvMhow0wWTkSl7RxookomD1MwcP4l5UStg5ShQ==",
-      "deprecated": "abandoned and unmaintained",
-      "license": "MIT",
-      "peerDependencies": {
-        "prop-types": ">=15",
-        "react": ">=0.14.9"
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -14715,6 +14746,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.9.tgz",
@@ -14885,6 +14931,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -17234,6 +17286,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@babel/core": "^7.16.0",
     "@fontsource/roboto": "^5.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
+    "@reduxjs/toolkit": "^2.5.0",
     "@svgr/webpack": "^5.5.0",
     "babel-jest": "^27.5.1",
     "babel-loader": "^8.2.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,15 +9,18 @@ import PostPage from 'pages/PostPage/PostPage';
 import PinnedPage from 'pages/PinnedPage';
 import NewsPage from 'pages/NewsPage';
 import BoardPage from 'pages/BoardPage';
+import ProfilePage from 'pages/ProfilePage';
 
 function App() {
   return (
-    <div className="App">
+    <div id='app-root'>
       <BrowserRouter>
         <Routes>
           <Route path='/login' element={<SignInPage/>}/>
           <Route path='/signup' element={<SignUpPage/>}/>
           <Route path='/admin' element={<AdminPage/>}/>
+          <Route path='/profile' element={<ProfilePage/>}/> 
+          <Route path='/profile/:id' element={<ProfilePage/>}/> 
           <Route path='/' element={<Home/>}>
             <Route path="/feeds" element={<FeedsPage/>}/>
             <Route path="/news/:id" element={<NewsPage />}/>

--- a/src/ModalRoot.tsx
+++ b/src/ModalRoot.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const ModalRootId = 'modal-root';
+
+function ModalRoot() {
+  
+  return <div id={ModalRootId}></div>;
+}
+
+export default ModalRoot;

--- a/src/components/FormField/FormField.module.css
+++ b/src/components/FormField/FormField.module.css
@@ -2,7 +2,7 @@
   --pad: .75rem;
   position: relative;
   margin: 0 auto;
-  width: 80%;
+  width: 100%;
 }
 
 .fieldInput {
@@ -10,7 +10,7 @@
   border: 2px solid black;
   outline: none;
   height: 3em;
-  width: 100%;
+  width: calc(100% - var(--pad));
 }
 
 .fieldInput::placeholder {

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -25,7 +25,6 @@ export default function FormField({
   return (
     <div className={classNames(className, styles.field)}>
       <input
-        id={name}
         className={classNames(
           styles.fieldInput,
           invalid? styles.fieldInputWrong : '',

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import NavButton from './NavButton';
+import React, { useRef, useState } from 'react';
+import NavButton, { NavButtonProps } from './NavButton';
 import styles from './NavBar.module.css';
 import AccountUrl from './icon_account.svg';
 import BoardUrl from './icon_board.svg';
@@ -7,15 +7,18 @@ import FeedsUrl from './icon_feeds.svg';
 import PinUrl from './icon_pin.svg';
 import SettingUrl from './icon_setting.svg';
 import classNames from 'classnames';
+import PageModal from 'components/PageModal';
+import SignUpCard from 'components/SignUpCard';
+import SignInCard from 'components/SignInCard';
+import ProfileCard from 'components/ProfileCard';
 
-interface ButtonInfo {
-  name: string;
-  link: string;
-  icon: any;
-}
+export default function Navbar({ className }: { className?: string }) {
+  const [isLoggedIn, setLoggedIn] = useState(false);
 
-export default function Navbar({className}: {className?: string}) {
-  const buttonInfos: ButtonInfo[] = [
+  const signInModalRef = useRef<HTMLDialogElement>(null);
+  const profileModalRef = useRef<HTMLDialogElement>(null);
+
+  const buttonInfos: NavButtonProps[] = [
     {
       name: 'feeds',
       link: '/feeds',
@@ -33,15 +36,40 @@ export default function Navbar({className}: {className?: string}) {
     },
   ];
 
+  const onLoginChanged = ({ target }: { target: HTMLInputElement }) => {
+    setLoggedIn(target.checked);
+  };
+
+  const onClickAccount = () => {
+    if (isLoggedIn) {
+      profileModalRef.current?.showModal();
+    } else {
+      signInModalRef.current?.showModal();
+    }
+  };
+
   return (
     <div className={classNames(className, styles.navbar)}>
-      <NavButton link="/login" icon={AccountUrl}/>
+      <input type="checkbox" onChange={(e) => onLoginChanged(e)} />
+      <NavButton name="account" icon={AccountUrl} onClick={onClickAccount} />
+
       <div className={styles.buttons}>
         {buttonInfos.map((info) => (
-          <NavButton key={info.name} link={info.link} icon={info.icon} />
+          <NavButton
+            key={info.name}
+            name="login"
+            link={info.link}
+            icon={info.icon}
+          />
         ))}
       </div>
-      <NavButton link="/setting" icon={SettingUrl}/>
+      <NavButton name="setting" link="/setting" icon={SettingUrl} />
+      <PageModal ref={signInModalRef} link="/login">
+        <SignInCard />
+      </PageModal>
+      <PageModal ref={profileModalRef} link="/profile">
+        <ProfileCard />
+      </PageModal>
     </div>
   );
 }

--- a/src/components/NavBar/NavButton.tsx
+++ b/src/components/NavBar/NavButton.tsx
@@ -2,18 +2,27 @@ import React, { ReactElement } from 'react';
 import styles from './NavBar.module.css';
 import { Link } from 'react-router-dom';
 
-export default function NavButton({
-  icon,
-  link,
-}: {
-  icon: any;
-  link: string;
-}) {
-  return (
-    <Link to={link}>
-      <div className={styles.button}>
-        <img src={icon} alt='button'/>
+export interface NavButtonProps {
+  name: string;
+  icon: string;
+  link?: string;
+  onClick?: () => void;
+}
+
+export default function NavButton({ icon, link, onClick }: NavButtonProps) {
+  if (link) {
+    return (
+      <Link to={link}>
+        <div className={styles.button}>
+          <img src={icon} alt="button" />
+        </div>
+      </Link>
+    );
+  } else {
+    return (
+      <div className={styles.button} onClick={() => onClick?.()}>
+        <img src={icon} alt="button" />
       </div>
-    </Link>
-  );
+    );
+  }
 }

--- a/src/components/PageModal/PageModal.module.css
+++ b/src/components/PageModal/PageModal.module.css
@@ -1,0 +1,19 @@
+.modal {
+
+}
+
+.wrapper {
+
+}
+
+.buttons {
+
+}
+
+.button {
+
+}
+
+.content {
+
+}

--- a/src/components/PageModal/PageModal.tsx
+++ b/src/components/PageModal/PageModal.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import { useState } from 'react';
+import styles from './PageModal.module.css';
+import classNames from 'classnames';
+import { ModalProps } from 'types/modal';
+import { ModalRootId } from 'ModalRoot';
+import { Link } from 'react-router-dom';
+
+export default function PageModal({
+  ref,
+  children,
+  buttons,
+  link,
+  onClose,
+}: ModalProps & {link: string}) {
+  const [isDOMReady, setDOMReady] = useState(false);
+
+  useEffect(() => {
+    setDOMReady(true);
+  }, []);
+
+  const handleClick = (e: React.MouseEvent<HTMLDialogElement, MouseEvent>) => {
+    const target = e.target as HTMLDialogElement
+    if (target.nodeName === 'DIALOG') {
+      target.close()
+    }
+  }
+
+  return isDOMReady
+    ? (ReactDOM.createPortal(
+      <dialog className={styles.modal} ref={ref} onClose={() => onClose?.()} onClick={(e) => handleClick(e)}>
+        <div className={styles.wrapper}>
+          <div className={styles.controls}>
+            <Link to={link} >
+              <span> original </span>
+            </Link>
+          </div>
+          <div className={styles.content}>{children}</div>
+          <div className={styles.buttons}>
+            <form method="dialog">
+              {buttons?.map((b) => (
+                <button
+                  className={styles.button}
+                  key={b.name}
+                  name={b.name}
+                  title={b.name}
+                  type="button"
+                  onClick={() => b.onClick?.()}
+                />
+              ))}
+            </form>
+          </div>
+        </div>
+      </dialog>,
+      document.getElementById(ModalRootId) as HTMLElement,
+    ))
+    : null;
+}

--- a/src/components/PageModal/index.ts
+++ b/src/components/PageModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PageModal';

--- a/src/components/ProfileCard/ProfileCard.module.css
+++ b/src/components/ProfileCard/ProfileCard.module.css
@@ -1,0 +1,41 @@
+
+.header {
+  display: flex;
+  justify-content: center;
+  text-align:center;
+  height: 6em;
+}
+
+
+.title {
+  margin: 0 auto;
+}
+
+.forms {
+  flex-grow: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
+}
+
+.field {
+  
+}
+
+.id {
+  
+}
+
+.password {
+
+}
+
+.menus {
+
+}

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -1,9 +1,9 @@
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import FormField from 'components/FormField';
-import styles from './SignUpCard.module.css';
+import styles from './ProfileCard.module.css';
 import classNames from 'classnames';
 
-interface SignUpCardProps {
+interface ProfileCardProps {
   username?: string;
   password?: string;
   email?: string;
@@ -11,13 +11,13 @@ interface SignUpCardProps {
   className?: string;
 }
 
-export default function SignUpCard({
+export default function ProfileCard({
   username: _username,
   password: _password,
   email: _email,
   nickname: _nickname,
   className
-}: SignUpCardProps) {
+}: ProfileCardProps) {
   const [username, setUsername] = useState(_username || '');
   const [isUsernameValid, setUsernameValid] = useState(true);
 
@@ -96,9 +96,9 @@ export default function SignUpCard({
   };
 
   return (
-    <div className={classNames(className, styles.signUpCard)}>
+    <div className={classNames(className, styles.profileCard)}>
       <div className={styles.header}>
-        <h1 className={styles.title}> signup </h1>
+        <h1 className={styles.title}> profile </h1>
       </div>
       <form
         className={styles.forms}
@@ -150,9 +150,10 @@ export default function SignUpCard({
             setNickname(e.target.value)
           }
         />
-        <button className={styles.confirm} title="회원가입" type="submit">회원가입</button>
+        <button type="submit" hidden></button>
       </form>
       <div className={styles.menus}>
+
       </div>
     </div>
   );

--- a/src/components/ProfileCard/index.ts
+++ b/src/components/ProfileCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ProfileCard';

--- a/src/components/SignInCard/SignInCard.module.css
+++ b/src/components/SignInCard/SignInCard.module.css
@@ -1,5 +1,4 @@
 .signInCard {
-  border: 2px solid black;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -9,25 +8,20 @@
   display: flex;
   justify-content: center;
   text-align:center;
-  height: 6em;
+  height: 5em;
 }
-
 
 .title {
   margin: 0 auto;
 }
 
 .forms {
-  flex-grow: 2;
-  display: flex;
-  flex-direction: column;
-  gap: 1em;
-}
-
-.fields {
+  width: 60%;
   display: flex;
   flex-direction: column;
   justify-content: stretch;
+  gap: 1em;
+  margin: 0 auto;
 }
 
 .field {
@@ -42,6 +36,16 @@
 
 }
 
-.menus {
+.confirm {
+  height: 3em; 
+  width: 100%;
+}
 
+.menus {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  justify-content:  space-between;
+  align-items: center;
+  padding: 1em 2em;
 }

--- a/src/components/SignInCard/SignInCard.tsx
+++ b/src/components/SignInCard/SignInCard.tsx
@@ -70,10 +70,18 @@ export default function SignInCard({
             setPassword(e.target.value)
           }
         />
-        <button type="submit" hidden></button>
+        <button className={styles.confirm} title="로그인" type="submit">
+          로그인
+        </button>
       </form>
       <div className={styles.menus}>
-        <Link to="/signup">Sign up</Link>
+        <Link to="/signup">
+          <span> 회원가입</span>
+        </Link>
+
+        {/*
+        <span> 도움... </span>
+        */}
       </div>
     </div>
   );

--- a/src/components/SignUpCard/SignUpCard.module.css
+++ b/src/components/SignUpCard/SignUpCard.module.css
@@ -1,5 +1,4 @@
 .signUpCard {
-  border: 2px solid black;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -8,40 +7,42 @@
 .header {
   display: flex;
   justify-content: center;
-  text-align:center;
-  height: 6em;
+  text-align: center;
+  height: 5em;
 }
-
 
 .title {
   margin: 0 auto;
 }
 
 .forms {
-  flex-grow: 2;
-  display: flex;
-  flex-direction: column;
-  gap: 1em;
-}
-
-.fields {
+  width: 60%;
   display: flex;
   flex-direction: column;
   justify-content: stretch;
+  gap: 1em;
+  margin: 0 auto;
 }
 
 .field {
-  
 }
 
 .id {
-  
 }
 
 .password {
+}
 
+.confirm {
+  height: 3em;
+  width: 100%;
 }
 
 .menus {
-
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1em 2em;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,15 @@
+* /* Hide scrollbar for Chrome, Safari and Opera */
+*::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+* {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}
+
+
 html {
   width: 100%;
   height: 100%;
@@ -5,15 +17,31 @@ html {
 
 body {
   width: inherit;
-  height: inherit
+  height: inherit;
 }
 
 #root {
+  position: relative;
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
-.App {
-  width: inherit;
-  height: inherit;
+#app-root {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+#modal-root {
+  position: absolute;
+  z-index: -1;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,15 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import "./index.css"
+import './index.css';
+import ModalRoot from 'ModalRoot';
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById('root') as HTMLElement,
 );
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+    <ModalRoot />
+  </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/pages/FeedsPage/FeedsPage.tsx
+++ b/src/pages/FeedsPage/FeedsPage.tsx
@@ -39,7 +39,143 @@ export default function FeedsPage() {
       ],
       logoImgUrl: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/X_logo_2023.svg/1134px-X_logo_2023.svg.png",
       logoUrl: "https://x.com/"
-    }
+    },
+    {
+      id: 1,
+      profile: {
+        name: "주르르",
+        id: "@jururu_twitch",
+        url: "https://x.com/jururu_twitch",
+        imgUrl: "https://pbs.twimg.com/profile_images/1723398787857854464/s7N2UgUv_200x200.jpg"
+      },
+      source: "x",
+      title: "임시 제목~",
+      content: "차세돌 엔딩기념! 연재전 컨셉아트 공개스 (여비날 님)",
+      date: new Date(),
+      url: "https://x.com/jururu_twitch/status/1816738805929632036",
+      attachments: [
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMFVua0AAxu1l?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMFm4aIAEl2Ps?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMF2DbwAAo36P?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMGEob0AAyGn2?format=jpg&name=360x360"
+        } as Img
+      ],
+      logoImgUrl: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/X_logo_2023.svg/1134px-X_logo_2023.svg.png",
+      logoUrl: "https://x.com/"
+    },
+    {
+      id: 1,
+      profile: {
+        name: "주르르",
+        id: "@jururu_twitch",
+        url: "https://x.com/jururu_twitch",
+        imgUrl: "https://pbs.twimg.com/profile_images/1723398787857854464/s7N2UgUv_200x200.jpg"
+      },
+      source: "x",
+      title: "임시 제목~",
+      content: "차세돌 엔딩기념! 연재전 컨셉아트 공개스 (여비날 님)",
+      date: new Date(),
+      url: "https://x.com/jururu_twitch/status/1816738805929632036",
+      attachments: [
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMFVua0AAxu1l?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMFm4aIAEl2Ps?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMF2DbwAAo36P?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMGEob0AAyGn2?format=jpg&name=360x360"
+        } as Img
+      ],
+      logoImgUrl: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/X_logo_2023.svg/1134px-X_logo_2023.svg.png",
+      logoUrl: "https://x.com/"
+    },
+    {
+      id: 1,
+      profile: {
+        name: "주르르",
+        id: "@jururu_twitch",
+        url: "https://x.com/jururu_twitch",
+        imgUrl: "https://pbs.twimg.com/profile_images/1723398787857854464/s7N2UgUv_200x200.jpg"
+      },
+      source: "x",
+      title: "임시 제목~",
+      content: "차세돌 엔딩기념! 연재전 컨셉아트 공개스 (여비날 님)",
+      date: new Date(),
+      url: "https://x.com/jururu_twitch/status/1816738805929632036",
+      attachments: [
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMFVua0AAxu1l?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMFm4aIAEl2Ps?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMF2DbwAAo36P?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMGEob0AAyGn2?format=jpg&name=360x360"
+        } as Img
+      ],
+      logoImgUrl: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/X_logo_2023.svg/1134px-X_logo_2023.svg.png",
+      logoUrl: "https://x.com/"
+    },
+    {
+      id: 1,
+      profile: {
+        name: "주르르",
+        id: "@jururu_twitch",
+        url: "https://x.com/jururu_twitch",
+        imgUrl: "https://pbs.twimg.com/profile_images/1723398787857854464/s7N2UgUv_200x200.jpg"
+      },
+      source: "x",
+      title: "임시 제목~",
+      content: "차세돌 엔딩기념! 연재전 컨셉아트 공개스 (여비날 님)",
+      date: new Date(),
+      url: "https://x.com/jururu_twitch/status/1816738805929632036",
+      attachments: [
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMFVua0AAxu1l?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMFm4aIAEl2Ps?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMF2DbwAAo36P?format=jpg&name=360x360"
+        } as Img,
+        {
+          type: "Img",
+          url: "https://pbs.twimg.com/media/GAQMGEob0AAyGn2?format=jpg&name=360x360"
+        } as Img
+      ],
+      logoImgUrl: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ce/X_logo_2023.svg/1134px-X_logo_2023.svg.png",
+      logoUrl: "https://x.com/"
+    },
   ];
 
   return (

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ProfilePage() {
+  return <div>ProfilePage</div>;
+}

--- a/src/pages/ProfilePage/index.ts
+++ b/src/pages/ProfilePage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ProfilePage';

--- a/src/pages/SignInPage/SignInPage.module.css
+++ b/src/pages/SignInPage/SignInPage.module.css
@@ -1,14 +1,52 @@
 .signInPage {
-  display:flex;
+  margin: auto;
+  display: flex;
+  justify-content: space-evenly;
   align-items: center;
   width: 100%;
   height: 100%;
 }
 
+.header {
+  width: 40vh;
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
 .signInCard {
   min-width: 400px;
   min-height: 300px;
-  width: 50vw;
+  width: 40vw;
   height: 50vh;
   margin: 0 auto;
+  border: 2px solid black;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.footer {
+}
+
+
+@media (max-width: 767px) {
+  /* 모바일 스타일 */
+  .signInPage {
+    flex-direction: column;
+  }
+}
+@media (min-width: 768px) and (max-width: 1024px) {
+  /* 태블릿 스타일 */
+  .signInPage {
+    flex-direction: row;
+  }
+}
+@media (min-width: 1025px) {
+  /* 데스크톱 스타일 */
+  .signInPage {
+    flex-direction: row;
+  }
 }

--- a/src/pages/SignInPage/SignInPage.tsx
+++ b/src/pages/SignInPage/SignInPage.tsx
@@ -1,9 +1,19 @@
 import SignInCard from 'components/SignInCard';
 import React from 'react';
-import styles from "./SignInPage.module.css"
+import styles from './SignInPage.module.css';
 
 export default function SignInPage() {
-  return <div className={styles.signInPage}>
-    <SignInCard className={styles.signInCard}/>
-  </div>;
+  return (
+    <div className={styles.signInPage}>
+      <div className={styles.header}>
+        <h1> header </h1>
+      </div>
+      <div className={styles.wrapper}>
+        <SignInCard className={styles.signInCard} />
+        <div className={styles.footer}>
+          <p> footer </p>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/SignUpPage/SignUpPage.module.css
+++ b/src/pages/SignUpPage/SignUpPage.module.css
@@ -1,14 +1,52 @@
 .signUpPage {
-  display:flex;
+  margin: auto;
+  display: flex;
+  justify-content: space-evenly;
   align-items: center;
   width: 100%;
   height: 100%;
 }
 
+.header {
+  width: 40vh;
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
 .signUpCard {
   min-width: 400px;
   min-height: 300px;
-  width: 50vw;
+  width: 40vw;
   height: 50vh;
   margin: 0 auto;
+  border: 2px solid black;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.footer {
+}
+
+
+@media (max-width: 767px) {
+  /* 모바일 스타일 */
+  .signUpPage {
+    flex-direction: column;
+  }
+}
+@media (min-width: 768px) and (max-width: 1024px) {
+  /* 태블릿 스타일 */
+  .signUpPage {
+    flex-direction: row;
+  }
+}
+@media (min-width: 1025px) {
+  /* 데스크톱 스타일 */
+  .signUpPage {
+    flex-direction: row;
+  }
 }

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -5,7 +5,15 @@ import React from 'react';
 export default function SignUpPage() {
   return (
     <div className={styles.signUpPage}>
-      <SignUpCard className={styles.signUpCard} />
+      <div className={styles.header}>
+        <h1> header </h1>
+      </div>
+      <div className={styles.wrapper}>
+        <SignUpCard className={styles.signUpCard} />
+        <div className={styles.footer}>
+          <p> footer </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -1,0 +1,25 @@
+import React, { ReactElement, ReactNode } from 'react';
+
+export type ModalButtonType = 'normal' | 'confirm' | 'abort';
+
+export type ModalIdType = string;
+
+export interface ModalControlButtonInfo {
+  icon: string;
+  onClick?: () => void;
+}
+
+export interface ModalActionButtonInfo {
+  name: string;
+  type: ModalButtonType;
+  onClick?: () => void;
+}
+
+export interface ModalProps {
+  ref: React.Ref<HTMLDialogElement>
+  children: ReactElement;
+  buttons?: ModalActionButtonInfo[];
+  onClose?: () => void;
+}
+
+export type ModalComponent = (props: ModalProps) => ReactNode


### PR DESCRIPTION
# what is new
- Clicking profile link in Main page opens a modal popup, sign-in page or profile page.
- Sign-in page and Sign-up page now contains header and footer

&nbsp;

![IMG_0040](https://github.com/user-attachments/assets/8bc6ff10-cb95-437d-8af5-c4511c7a6bfd)
![IMG_0041](https://github.com/user-attachments/assets/76715744-23e5-4176-b7ed-b68c220f8e29)

# additional description
- Profile 링크 위에 있는 checkbox는 로그인 여부를 임시로 변경할 수 있게 해둔 것
- Modal popup 위에 있는 original은 임시로 추가한 것으로, 나중에 Icon 버튼으로 변경